### PR TITLE
[supabase] test(db): add pgTAP test suite + server-manage device timestamps

### DIFF
--- a/app/lib/core/drift/devices_table.dart
+++ b/app/lib/core/drift/devices_table.dart
@@ -20,9 +20,4 @@ class Devices extends Table {
       textEnum<OperatingSystem>().named('os_id')();
   TextColumn get osVersion => text().named('os_version')();
   TextColumn get appVersion => text().named('app_version')();
-
-  DateTimeColumn get createdAt =>
-      dateTime().named('created_at').clientDefault(() => DateTime.now())();
-  DateTimeColumn get updatedAt =>
-      dateTime().named('updated_at').clientDefault(() => DateTime.now())();
 }

--- a/app/lib/core/drift/schema.dart
+++ b/app/lib/core/drift/schema.dart
@@ -31,8 +31,6 @@ Schema schema = const Schema(([
     Column.text('os_id'),
     Column.text('os_version'),
     Column.text('app_version'),
-    Column.text('created_at'),
-    Column.text('updated_at'),
   ]),
   Table('raw_location_data', [
     Column.text('user_id'),

--- a/app/lib/features/authentication/domain/models/device.dart
+++ b/app/lib/features/authentication/domain/models/device.dart
@@ -20,8 +20,6 @@ class Device extends Equatable {
     required this.operatingSystem,
     required this.osVersion,
     required this.appVersion,
-    required this.createdAt,
-    required this.updatedAt,
   }) : id = id ?? (const Uuid()).v4();
 
   /// Rebuilds a device record from database values.
@@ -34,8 +32,6 @@ class Device extends Equatable {
     required OperatingSystem operatingSystem,
     required String osVersion,
     required String appVersion,
-    required DateTime createdAt,
-    required DateTime updatedAt,
   }) {
     return Device(
       id: id,
@@ -46,8 +42,6 @@ class Device extends Equatable {
       operatingSystem: operatingSystem,
       osVersion: osVersion,
       appVersion: appVersion,
-      createdAt: createdAt,
-      updatedAt: updatedAt,
     );
   }
 
@@ -59,8 +53,6 @@ class Device extends Equatable {
   final OperatingSystem operatingSystem;
   final String osVersion;
   final String appVersion;
-  final DateTime createdAt;
-  final DateTime updatedAt;
 
   /// Creates a user-scoped device record from platform-provided device info.
   ///
@@ -73,8 +65,6 @@ class Device extends Equatable {
     required String appVersion,
     required String userId,
   }) {
-    final DateTime now = DateTime.now();
-
     return Device(
       userId: userId,
       name: rawDevice.name,
@@ -83,8 +73,6 @@ class Device extends Equatable {
       operatingSystem: rawDevice.os,
       osVersion: rawDevice.osVersion,
       appVersion: appVersion,
-      createdAt: now,
-      updatedAt: now,
     );
   }
 
@@ -98,7 +86,5 @@ class Device extends Equatable {
     operatingSystem,
     osVersion,
     appVersion,
-    createdAt,
-    updatedAt,
   ];
 }

--- a/app/test/fixtures.dart
+++ b/app/test/fixtures.dart
@@ -301,8 +301,6 @@ final Device tDevice = Device(
   operatingSystem: OperatingSystem.ios,
   osVersion: '18.4.1',
   appVersion: '0.0.1',
-  createdAt: tStartDate,
-  updatedAt: tEndDate,
 );
 
 const RawDevice tAndroidRawDevice = RawDevice(

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -329,10 +329,6 @@ s3_access_key = "env(S3_ACCESS_KEY)"
 s3_secret_key = "env(S3_SECRET_KEY)"
 
 
-[auth.hook.custom_access_token]
-enabled = true
-uri = "pg-functions://postgres/public/user_roles_hook"
-
 [functions.sign_up_initial_admin]
 enabled = true
 verify_jwt = false

--- a/supabase/migrations/20260526135937_basic_schema.sql
+++ b/supabase/migrations/20260526135937_basic_schema.sql
@@ -1,5 +1,9 @@
 create extension if not exists "moddatetime" with schema "extensions";
 
+create extension if not exists "pgtap" with schema "extensions";
+
+create extension if not exists "postgis" with schema "extensions";
+
 create type "public"."activity_type" as enum ('still', 'walking', 'on_foot', 'running', 'on_bicycle', 'in_vehicle', 'unknown');
 
 create type "public"."location_recording_trigger" as enum ('standard', 'significant_change');
@@ -31,8 +35,8 @@ alter table "public"."activity_segments" enable row level security;
     "os_version" text not null,
     "app_version" text not null,
     "manufacturer" text not null,
-    "created_at" timestamp with time zone not null,
-    "updated_at" timestamp with time zone not null
+    "created_at" timestamp with time zone not null default (now() AT TIME ZONE 'utc'::text),
+    "updated_at" timestamp with time zone not null default (now() AT TIME ZONE 'utc'::text)
       );
 
 
@@ -215,10 +219,6 @@ alter table "public"."visits" validate constraint "visits_user_id_fkey";
 
 alter table "public"."visits" add constraint "visits_user_id_id_key" UNIQUE using index "visits_user_id_id_key";
 
--- PowerSync role must exist before grants reference it.
--- Password is set at deploy time by migrate.sh (runtime secret; not in migrations).
-create role powersync_role with replication bypassrls login;
-
 set check_function_bodies = off;
 
 CREATE OR REPLACE FUNCTION public.has_permission(requested_permission public.permissions)
@@ -246,8 +246,6 @@ grant select on table "public"."activity_segments" to "authenticated";
 
 grant update on table "public"."activity_segments" to "authenticated";
 
-grant select on table "public"."activity_segments" to "powersync_role";
-
 grant delete on table "public"."activity_segments" to "service_role";
 
 grant insert on table "public"."activity_segments" to "service_role";
@@ -261,14 +259,6 @@ grant trigger on table "public"."activity_segments" to "service_role";
 grant truncate on table "public"."activity_segments" to "service_role";
 
 grant update on table "public"."activity_segments" to "service_role";
-
-grant insert on table "public"."devices" to "authenticated";
-
-grant select on table "public"."devices" to "authenticated";
-
-grant update on table "public"."devices" to "authenticated";
-
-grant select on table "public"."devices" to "powersync_role";
 
 grant delete on table "public"."devices" to "service_role";
 
@@ -287,8 +277,6 @@ grant update on table "public"."devices" to "service_role";
 grant select on table "public"."public_info" to "anon";
 
 grant select on table "public"."public_info" to "authenticated";
-
-grant select on table "public"."public_info" to "powersync_role";
 
 grant delete on table "public"."public_info" to "service_role";
 
@@ -310,8 +298,6 @@ grant select on table "public"."raw_location_data" to "authenticated";
 
 grant update on table "public"."raw_location_data" to "authenticated";
 
-grant select on table "public"."raw_location_data" to "powersync_role";
-
 grant delete on table "public"."raw_location_data" to "service_role";
 
 grant insert on table "public"."raw_location_data" to "service_role";
@@ -327,8 +313,6 @@ grant truncate on table "public"."raw_location_data" to "service_role";
 grant update on table "public"."raw_location_data" to "service_role";
 
 grant select on table "public"."role_permissions" to "authenticated";
-
-grant select on table "public"."role_permissions" to "powersync_role";
 
 grant delete on table "public"."role_permissions" to "service_role";
 
@@ -346,8 +330,6 @@ grant update on table "public"."role_permissions" to "service_role";
 
 grant select on table "public"."user_roles" to "authenticated";
 
-grant select on table "public"."user_roles" to "powersync_role";
-
 grant delete on table "public"."user_roles" to "service_role";
 
 grant insert on table "public"."user_roles" to "service_role";
@@ -361,8 +343,6 @@ grant trigger on table "public"."user_roles" to "service_role";
 grant truncate on table "public"."user_roles" to "service_role";
 
 grant update on table "public"."user_roles" to "service_role";
-
-grant select on table "public"."users" to "powersync_role";
 
 grant delete on table "public"."users" to "service_role";
 
@@ -383,8 +363,6 @@ grant insert on table "public"."visits" to "authenticated";
 grant select on table "public"."visits" to "authenticated";
 
 grant update on table "public"."visits" to "authenticated";
-
-grant select on table "public"."visits" to "powersync_role";
 
 grant delete on table "public"."visits" to "service_role";
 
@@ -539,14 +517,16 @@ using ((( SELECT auth.uid() AS uid) = user_id))
 with check ((( SELECT auth.uid() AS uid) = user_id));
 
 
+CREATE TRIGGER handle_updated_at BEFORE UPDATE ON public.devices FOR EACH ROW EXECUTE FUNCTION extensions.moddatetime('updated_at');
+
 CREATE TRIGGER handle_updated_at BEFORE UPDATE ON public.user_roles FOR EACH ROW EXECUTE FUNCTION extensions.moddatetime('updated_at');
 
 CREATE TRIGGER handle_updated_at BEFORE UPDATE ON public.users FOR EACH ROW EXECUTE FUNCTION extensions.moddatetime('updated_at');
 
-------------------------
--- Manual modifications
--- (not captured by db diff: revokes, seed data, powersync role/publication)
-------------------------
+-- Manual modifications (not captured by db diff)
+
+-- PowerSync replication role (password set at deploy time).
+create role powersync_role with replication bypassrls login;
 
 -- activity_segments
 revoke select, insert, update, delete, references, trigger, truncate on table "public"."activity_segments" from anon;
@@ -554,7 +534,10 @@ revoke delete, references, trigger, truncate on table "public"."activity_segment
 
 -- devices
 revoke select, insert, update, delete, references, trigger, truncate on table "public"."devices" from anon;
-revoke delete, references, trigger, truncate on table "public"."devices" from authenticated;
+revoke select, insert, update, delete, references, trigger, truncate on table "public"."devices" from authenticated;
+grant select (id, user_id, name, model, os_id, os_version, app_version, manufacturer) on table "public"."devices" to authenticated;
+grant insert (id, user_id, name, model, os_id, os_version, app_version, manufacturer) on table "public"."devices" to authenticated;
+grant update (id, user_id, name, model, os_id, os_version, app_version, manufacturer) on table "public"."devices" to authenticated;
 
 -- public_info
 revoke insert, update, delete, references, trigger, truncate on table "public"."public_info" from anon;
@@ -580,15 +563,18 @@ revoke select, insert, update, delete, references, trigger, truncate on table "p
 revoke select, insert, update, delete, references, trigger, truncate on table "public"."visits" from anon;
 revoke delete, references, trigger, truncate on table "public"."visits" from authenticated;
 
--- Seed data
-insert into "public"."role_permissions" ("id", "role", "permission") values
-  ('9c7ff33b-08d9-4082-b966-c503f6ec2207', 'admin', 'read.users'),
-  ('35e876c2-809c-4d3d-9a01-56e1cabbeddf', 'admin', 'write.users');
+-- PowerSync read access and publication
+grant select on
+  public.public_info,
+  public.role_permissions,
+  public.users,
+  public.devices,
+  public.raw_location_data,
+  public.activity_segments,
+  public.visits,
+  public.user_roles
+to powersync_role;
 
-insert into "public"."public_info" ("name", "value") values
-  ('is_set_up', 'false');
-
--- PowerSync publication
 create publication powersync for table
   public.public_info,
   public.role_permissions,
@@ -598,3 +584,12 @@ create publication powersync for table
   public.activity_segments,
   public.visits,
   public.user_roles;
+
+-- Seed data
+insert into "public"."role_permissions" ("id", "role", "permission") values
+  ('9c7ff33b-08d9-4082-b966-c503f6ec2207', 'admin', 'read.users'),
+  ('35e876c2-809c-4d3d-9a01-56e1cabbeddf', 'admin', 'write.users');
+
+insert into "public"."public_info" ("name", "value") values
+  ('is_set_up', 'false');
+

--- a/supabase/powersync/config/sync_rules.yaml
+++ b/supabase/powersync/config/sync_rules.yaml
@@ -50,9 +50,7 @@ streams:
           os_id,
           os_version,
           app_version,
-          manufacturer,
-          created_at,
-          updated_at
+          manufacturer
         FROM devices
         WHERE user_id IN current_user_id
       - |

--- a/supabase/schemas/devices/20_table.sql
+++ b/supabase/schemas/devices/20_table.sql
@@ -7,8 +7,8 @@ create table "public"."devices" (
   "os_version" text not null,
   "app_version" text not null,
   "manufacturer" text not null,
-  "created_at" timestamp with time zone not null,
-  "updated_at" timestamp with time zone not null,
+  "created_at" timestamp with time zone not null default (now() at time zone 'utc'::text),
+  "updated_at" timestamp with time zone not null default (now() at time zone 'utc'::text),
   primary key ("id"),
   unique ("user_id", "id")
 );

--- a/supabase/schemas/devices/30_grants.sql
+++ b/supabase/schemas/devices/30_grants.sql
@@ -2,4 +2,9 @@
 revoke select, insert, update, delete, references, trigger, truncate on table "public"."devices" from anon;
 revoke select, insert, update, delete, references, trigger, truncate on table "public"."devices" from authenticated;
 
-grant select, insert, update on table "public"."devices" to authenticated;
+grant select (id, user_id, name, model, os_id, os_version, app_version, manufacturer)
+  on table "public"."devices" to authenticated;
+grant insert (id, user_id, name, model, os_id, os_version, app_version, manufacturer)
+  on table "public"."devices" to authenticated;
+grant update (id, user_id, name, model, os_id, os_version, app_version, manufacturer)
+  on table "public"."devices" to authenticated;

--- a/supabase/schemas/updated_at_trigger.sql
+++ b/supabase/schemas/updated_at_trigger.sql
@@ -1,4 +1,5 @@
 create extension if not exists "moddatetime" with schema "extensions";
 
+create trigger handle_updated_at before update on public.devices for each row execute function extensions.moddatetime ('updated_at');
 create trigger handle_updated_at before update on public.user_roles for each row execute function extensions.moddatetime ('updated_at');
 create trigger handle_updated_at before update on public.users for each row execute function extensions.moddatetime ('updated_at');

--- a/supabase/tests/database/00_test_helpers.sql
+++ b/supabase/tests/database/00_test_helpers.sql
@@ -1,0 +1,93 @@
+-- Helper functions for pgTAP grant/privilege assertions.
+-- Loaded automatically before test files by pg_prove (alphabetical order).
+-- Do NOT add \ir for this file in test files.
+SELECT plan(1);
+
+CREATE SCHEMA IF NOT EXISTS test_helpers;
+
+-- Returns sorted columns a role has the given privilege type on (e.g. 'INSERT', 'SELECT').
+CREATE OR REPLACE FUNCTION test_helpers.col_privs(p_table text, p_role text, p_priv text)
+RETURNS text[] LANGUAGE sql STABLE AS $$
+  SELECT coalesce(array_agg(column_name::text ORDER BY column_name), ARRAY[]::text[])
+  FROM information_schema.column_privileges
+  WHERE table_schema    = 'public'
+    AND table_name      = p_table
+    AND grantee         = p_role
+    AND privilege_type  = p_priv;
+$$;
+
+-- Returns sorted grantees that hold any table-level privilege, excluding postgres,
+-- PUBLIC, and Supabase/PowerSync system roles. Only client-facing roles that the
+-- application explicitly grants to (anon, authenticated) should appear.
+CREATE OR REPLACE FUNCTION test_helpers.table_grantees(p_table text)
+RETURNS text[] LANGUAGE sql STABLE AS $$
+  SELECT coalesce(array_agg(grantee ORDER BY grantee), ARRAY[]::text[])
+  FROM (
+    SELECT DISTINCT grantee::text
+    FROM information_schema.table_privileges
+    WHERE table_schema = 'public'
+      AND table_name   = p_table
+      AND grantee NOT IN ('postgres', 'PUBLIC', 'service_role',
+                          'supabase_admin', 'supabase_auth_admin',
+                          'supabase_storage_admin', 'supabase_replication_admin',
+                          'dashboard_user', 'pgsodium_keyiduser', 'pgsodium_keyholder',
+                          'pgsodium_keymaker', 'powersync_role')
+  ) t;
+$$;
+
+-- Returns sorted distinct privilege types a role holds on a table (table-level + column-level combined).
+CREATE OR REPLACE FUNCTION test_helpers.all_privs(p_table text, p_role text)
+RETURNS text[] LANGUAGE sql STABLE AS $$
+  SELECT coalesce(array_agg(privilege_type ORDER BY privilege_type), ARRAY[]::text[])
+  FROM (
+    SELECT DISTINCT privilege_type::text
+    FROM (
+      SELECT privilege_type FROM information_schema.table_privileges
+      WHERE table_schema = 'public' AND table_name = p_table AND grantee = p_role
+      UNION
+      SELECT privilege_type FROM information_schema.column_privileges
+      WHERE table_schema = 'public' AND table_name = p_table AND grantee = p_role
+    ) raw
+  ) combined;
+$$;
+
+-- Simulate an authenticated user by setting the JWT claims so auth.uid() returns p_user_id.
+-- Use before SET LOCAL ROLE authenticated; reset with reset_actor().
+CREATE OR REPLACE FUNCTION test_helpers.set_actor(p_user_id uuid)
+RETURNS void LANGUAGE sql AS $$
+  SELECT set_config('request.jwt.claims',
+    format('{"sub": "%s", "role": "authenticated"}', p_user_id),
+    true);
+$$;
+
+-- Clear JWT claims after a role-scoped test block.
+CREATE OR REPLACE FUNCTION test_helpers.reset_actor()
+RETURNS void LANGUAGE sql AS $$
+  SELECT set_config('request.jwt.claims', '{}', true);
+$$;
+
+-- Insert minimal auth.users + public.users rows for a test fixture user.
+-- Idempotent so a single test can call it for the same uuid more than once.
+CREATE OR REPLACE FUNCTION test_helpers.create_user(p_user_id uuid)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE
+  v_email text := p_user_id::text || '@test.local';
+BEGIN
+  INSERT INTO auth.users (id, instance_id, aud, role, email)
+  VALUES (p_user_id, '00000000-0000-0000-0000-000000000000',
+          'authenticated', 'authenticated', v_email)
+  ON CONFLICT (id) DO NOTHING;
+
+  INSERT INTO public.users (id, email, username)
+  VALUES (p_user_id, v_email, p_user_id::text)
+  ON CONFLICT (id) DO NOTHING;
+END;
+$$;
+
+-- Allow authenticated callers to set their own JWT claims during a test block.
+GRANT USAGE ON SCHEMA test_helpers TO authenticated, anon;
+GRANT EXECUTE ON FUNCTION test_helpers.set_actor(uuid) TO authenticated, anon;
+GRANT EXECUTE ON FUNCTION test_helpers.reset_actor() TO authenticated, anon;
+
+SELECT pass('test_helpers loaded');
+SELECT * FROM finish();

--- a/supabase/tests/database/activity_segments_test.sql
+++ b/supabase/tests/database/activity_segments_test.sql
@@ -1,0 +1,90 @@
+BEGIN;
+SELECT no_plan();
+
+-- Grants -----------------------------------------------------------------------
+
+SELECT is(
+  test_helpers.col_privs('activity_segments', 'authenticated', 'INSERT'),
+  ARRAY['end_location_id', 'id', 'start_location_id', 'user_id'],
+  'authenticated can INSERT every column on activity_segments'
+);
+SELECT is(
+  test_helpers.table_grantees('activity_segments'),
+  ARRAY['authenticated'],
+  'authenticated is the only role with table-level privileges'
+);
+SELECT is(
+  test_helpers.all_privs('activity_segments', 'authenticated'),
+  ARRAY['INSERT', 'SELECT', 'UPDATE'],
+  'authenticated has exactly INSERT, SELECT, UPDATE privileges'
+);
+
+-- RLS: SELECT ------------------------------------------------------------------
+SELECT test_helpers.create_user('11111111-1111-1111-1111-111111111111');
+SELECT test_helpers.create_user('22222222-2222-2222-2222-222222222222');
+
+INSERT INTO public.activity_segments (id, user_id) VALUES
+  ('seg-owner', '11111111-1111-1111-1111-111111111111'),
+  ('seg-other', '22222222-2222-2222-2222-222222222222');
+
+-- allowed: owner sees only their own segments
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT results_eq(
+  $$SELECT id FROM public.activity_segments ORDER BY id$$,
+  $$VALUES ('seg-owner'::text)$$,
+  'allowed: authenticated owner sees only own activity segments'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- denied: non-owner cannot read another user's segment
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('22222222-2222-2222-2222-222222222222');
+SELECT is_empty(
+  $$SELECT id FROM public.activity_segments WHERE id = 'seg-owner'$$,
+  'denied: non-owner cannot SELECT another user''s activity segment'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- RLS: INSERT ------------------------------------------------------------------
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT throws_ok(
+  $$INSERT INTO public.activity_segments (id, user_id)
+    VALUES ('seg-spoof', '22222222-2222-2222-2222-222222222222')$$,
+  '42501',
+  NULL,
+  'denied: authenticated cannot INSERT a segment for a different user_id'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- RLS: UPDATE ------------------------------------------------------------------
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT is_empty(
+  $$WITH updated AS (
+      UPDATE public.activity_segments SET start_location_id = NULL
+      WHERE id = 'seg-other'
+      RETURNING id
+    )
+    SELECT id FROM updated$$,
+  'denied: non-owner UPDATE returns no rows'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- denied: owner cannot reassign their own row to another user_id (WITH CHECK)
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT throws_ok(
+  $$UPDATE public.activity_segments
+    SET user_id = '22222222-2222-2222-2222-222222222222'
+    WHERE id = 'seg-owner'$$,
+  '42501',
+  NULL,
+  'denied: owner cannot UPDATE user_id to another user (WITH CHECK)'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- ------------------------------------------------------------------------------
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/devices_test.sql
+++ b/supabase/tests/database/devices_test.sql
@@ -1,0 +1,104 @@
+BEGIN;
+SELECT no_plan();
+
+-- Grants -----------------------------------------------------------------------
+
+SELECT is(
+  test_helpers.col_privs('devices', 'authenticated', 'SELECT'),
+  ARRAY['app_version', 'id', 'manufacturer', 'model',
+        'name', 'os_id', 'os_version', 'user_id'],
+  'authenticated can SELECT only the granted columns on devices (created_at/updated_at hidden)'
+);
+SELECT is(
+  test_helpers.col_privs('devices', 'authenticated', 'INSERT'),
+  ARRAY['app_version', 'id', 'manufacturer', 'model',
+        'name', 'os_id', 'os_version', 'user_id'],
+  'authenticated can INSERT only the granted columns on devices (created_at/updated_at are server-managed)'
+);
+SELECT is(
+  test_helpers.table_grantees('devices'),
+  ARRAY[]::text[],
+  'no role has table-level privileges (authenticated grants are column-level only)'
+);
+SELECT is(
+  test_helpers.all_privs('devices', 'authenticated'),
+  ARRAY['INSERT', 'SELECT', 'UPDATE'],
+  'authenticated has exactly INSERT, SELECT, UPDATE privileges'
+);
+
+-- RLS: SELECT ------------------------------------------------------------------
+-- seed two users with one device each
+SELECT test_helpers.create_user('11111111-1111-1111-1111-111111111111');
+SELECT test_helpers.create_user('22222222-2222-2222-2222-222222222222');
+
+INSERT INTO public.devices (id, user_id, name, model, os_version, app_version, manufacturer, created_at, updated_at)
+VALUES ('device-owner', '11111111-1111-1111-1111-111111111111',
+        'Owner Phone', 'Pixel 8', '14', '1.0.0', 'Google', now(), now());
+INSERT INTO public.devices (id, user_id, name, model, os_version, app_version, manufacturer, created_at, updated_at)
+VALUES ('device-other', '22222222-2222-2222-2222-222222222222',
+        'Other Phone', 'iPhone 15', '17', '1.0.0', 'Apple', now(), now());
+
+-- allowed: owner sees only their own device
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT results_eq(
+  $$SELECT id FROM public.devices ORDER BY id$$,
+  $$VALUES ('device-owner'::text)$$,
+  'allowed: authenticated owner sees only own devices'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- denied: non-owner sees nothing for that row
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('22222222-2222-2222-2222-222222222222');
+SELECT is_empty(
+  $$SELECT id FROM public.devices WHERE id = 'device-owner'$$,
+  'denied: non-owner cannot SELECT another user''s device'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- RLS: INSERT ------------------------------------------------------------------
+-- denied: cannot insert a device claiming another user's id
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT throws_ok(
+  $$INSERT INTO public.devices (id, user_id, name, model, os_version, app_version, manufacturer, created_at, updated_at)
+    VALUES ('device-spoof', '22222222-2222-2222-2222-222222222222',
+            'Spoof', 'X', '0', '0', 'X', now(), now())$$,
+  '42501',
+  NULL,
+  'denied: authenticated cannot INSERT a device for a different user_id'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- RLS: UPDATE ------------------------------------------------------------------
+-- denied: updating another user's device affects zero rows
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT is_empty(
+  $$WITH updated AS (
+      UPDATE public.devices SET name = 'hijacked'
+      WHERE id = 'device-other'
+      RETURNING id
+    )
+    SELECT id FROM updated$$,
+  'denied: non-owner UPDATE returns no rows'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- denied: owner cannot reassign their own row to another user_id (WITH CHECK)
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT throws_ok(
+  $$UPDATE public.devices
+    SET user_id = '22222222-2222-2222-2222-222222222222'
+    WHERE id = 'device-owner'$$,
+  '42501',
+  NULL,
+  'denied: owner cannot UPDATE user_id to another user (WITH CHECK)'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- ------------------------------------------------------------------------------
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/has_permission_test.sql
+++ b/supabase/tests/database/has_permission_test.sql
@@ -1,0 +1,59 @@
+BEGIN;
+SELECT no_plan();
+
+-- has_permission(requested_permission) returns true iff the caller (auth.uid())
+-- has an accepted, undeleted user_role whose role grants the requested permission.
+-- Seed data: admin role grants read.users + write.users.
+
+SELECT test_helpers.create_user('11111111-1111-1111-1111-111111111111');
+SELECT test_helpers.create_user('22222222-2222-2222-2222-222222222222');
+
+-- Case 1: accepted admin role → true ------------------------------------------
+INSERT INTO public.user_roles (id, user_id, role, accepted_at)
+VALUES ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        '11111111-1111-1111-1111-111111111111', 'admin', now());
+
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT ok(
+  public.has_permission('read.users'),
+  'accepted admin → has_permission(read.users) is true'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- Case 2: pending role (accepted_at IS NULL) → false --------------------------
+UPDATE public.user_roles SET accepted_at = NULL
+WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT ok(
+  NOT public.has_permission('read.users'),
+  'pending role → has_permission(read.users) is false'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- Case 3: accepted but soft-deleted role → false ------------------------------
+UPDATE public.user_roles SET accepted_at = now(), deleted_at = now()
+WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT ok(
+  NOT public.has_permission('read.users'),
+  'deleted role → has_permission(read.users) is false'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- Case 4: user has no role at all → false -------------------------------------
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('22222222-2222-2222-2222-222222222222');
+SELECT ok(
+  NOT public.has_permission('read.users'),
+  'missing role → has_permission(read.users) is false'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- ------------------------------------------------------------------------------
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/public_info_test.sql
+++ b/supabase/tests/database/public_info_test.sql
@@ -1,0 +1,46 @@
+BEGIN;
+SELECT no_plan();
+
+-- Grants -----------------------------------------------------------------------
+
+SELECT is(
+  test_helpers.col_privs('public_info', 'anon', 'SELECT'),
+  ARRAY['id', 'name', 'value'],
+  'anon can SELECT only the granted columns on public_info'
+);
+SELECT is(
+  test_helpers.table_grantees('public_info'),
+  ARRAY['anon', 'authenticated'],
+  'anon and authenticated are the roles with table-level privileges'
+);
+SELECT is(
+  test_helpers.all_privs('public_info', 'anon'),
+  ARRAY['SELECT'],
+  'anon has exactly SELECT privileges'
+);
+
+-- RLS: SELECT ------------------------------------------------------------------
+-- The policy is `to public using (true)`. Both anon and signed-in users must see
+-- the catalog row that drives the setup wizard.
+
+-- allowed: anon (the setup wizard runs before any user exists)
+SET LOCAL ROLE anon;
+SELECT isnt_empty(
+  $$SELECT name FROM public.public_info WHERE name = 'is_set_up'$$,
+  'allowed: anon can SELECT the is_set_up row'
+);
+RESET ROLE;
+
+-- allowed: authenticated
+SELECT test_helpers.create_user('11111111-1111-1111-1111-111111111111');
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT isnt_empty(
+  $$SELECT name FROM public.public_info WHERE name = 'is_set_up'$$,
+  'allowed: authenticated can SELECT the is_set_up row'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- ------------------------------------------------------------------------------
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/raw_location_data_test.sql
+++ b/supabase/tests/database/raw_location_data_test.sql
@@ -1,0 +1,118 @@
+BEGIN;
+SELECT no_plan();
+
+-- Grants -----------------------------------------------------------------------
+
+SELECT is(
+  test_helpers.col_privs('raw_location_data', 'authenticated', 'INSERT'),
+  ARRAY['activity_confidence', 'activity_type_id', 'altitude_accuracy',
+        'battery_level', 'coordinates_accuracy', 'device_id',
+        'ellipsoidal_altitude', 'heading', 'heading_accuracy', 'id',
+        'is_device_charging', 'latitude', 'longitude', 'recording_trigger',
+        'speed', 'speed_accuracy', 'timestamp', 'user_id'],
+  'authenticated can INSERT every column on raw_location_data'
+);
+SELECT is(
+  test_helpers.table_grantees('raw_location_data'),
+  ARRAY['authenticated'],
+  'authenticated is the only role with table-level privileges'
+);
+SELECT is(
+  test_helpers.all_privs('raw_location_data', 'authenticated'),
+  ARRAY['INSERT', 'SELECT', 'UPDATE'],
+  'authenticated has exactly INSERT, SELECT, UPDATE privileges'
+);
+
+-- RLS: SELECT ------------------------------------------------------------------
+-- seed users + one device each + one location reading each
+SELECT test_helpers.create_user('11111111-1111-1111-1111-111111111111');
+SELECT test_helpers.create_user('22222222-2222-2222-2222-222222222222');
+
+INSERT INTO public.devices (id, user_id, name, model, os_version, app_version, manufacturer, created_at, updated_at)
+VALUES ('device-owner', '11111111-1111-1111-1111-111111111111',
+        'Owner Phone', 'Pixel 8', '14', '1.0.0', 'Google', now(), now()),
+       ('device-other', '22222222-2222-2222-2222-222222222222',
+        'Other Phone', 'iPhone 15', '17', '1.0.0', 'Apple', now(), now());
+
+INSERT INTO public.raw_location_data (
+  id, user_id, device_id, latitude, longitude, coordinates_accuracy,
+  speed, speed_accuracy, heading, heading_accuracy,
+  ellipsoidal_altitude, altitude_accuracy, activity_confidence,
+  battery_level, is_device_charging, timestamp
+) VALUES (
+  'loc-owner', '11111111-1111-1111-1111-111111111111', 'device-owner',
+  52.5, 13.4, 5, 0, 0, 0, 0, 30, 5, 0.9, 0.8, false, now()
+), (
+  'loc-other', '22222222-2222-2222-2222-222222222222', 'device-other',
+  52.5, 13.4, 5, 0, 0, 0, 0, 30, 5, 0.9, 0.8, false, now()
+);
+
+-- allowed: owner sees only their own readings
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT results_eq(
+  $$SELECT id FROM public.raw_location_data ORDER BY id$$,
+  $$VALUES ('loc-owner'::text)$$,
+  'allowed: authenticated owner sees only own location readings'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- denied: non-owner cannot read another user's location data
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('22222222-2222-2222-2222-222222222222');
+SELECT is_empty(
+  $$SELECT id FROM public.raw_location_data WHERE id = 'loc-owner'$$,
+  'denied: non-owner cannot SELECT another user''s location readings'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- RLS: INSERT ------------------------------------------------------------------
+-- denied: cannot insert a reading attributed to another user
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT throws_ok(
+  $$INSERT INTO public.raw_location_data (
+      id, user_id, device_id, latitude, longitude, coordinates_accuracy,
+      speed, speed_accuracy, heading, heading_accuracy,
+      ellipsoidal_altitude, altitude_accuracy, activity_confidence,
+      battery_level, is_device_charging, timestamp
+    ) VALUES (
+      'loc-spoof', '22222222-2222-2222-2222-222222222222', 'device-other',
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false, now()
+    )$$,
+  '42501',
+  NULL,
+  'denied: authenticated cannot INSERT a reading for a different user_id'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- RLS: UPDATE ------------------------------------------------------------------
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT is_empty(
+  $$WITH updated AS (
+      UPDATE public.raw_location_data SET battery_level = 0
+      WHERE id = 'loc-other'
+      RETURNING id
+    )
+    SELECT id FROM updated$$,
+  'denied: non-owner UPDATE returns no rows'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- denied: owner cannot reassign their own row to another user_id (WITH CHECK)
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT throws_ok(
+  $$UPDATE public.raw_location_data
+    SET user_id = '22222222-2222-2222-2222-222222222222'
+    WHERE id = 'loc-owner'$$,
+  '42501',
+  NULL,
+  'denied: owner cannot UPDATE user_id to another user (WITH CHECK)'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- ------------------------------------------------------------------------------
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/role_permissions_test.sql
+++ b/supabase/tests/database/role_permissions_test.sql
@@ -1,0 +1,48 @@
+BEGIN;
+SELECT no_plan();
+
+-- Grants -----------------------------------------------------------------------
+
+SELECT is(
+  test_helpers.col_privs('role_permissions', 'authenticated', 'SELECT'),
+  ARRAY['id', 'permission', 'role'],
+  'authenticated can SELECT only the granted columns on role_permissions'
+);
+SELECT is(
+  test_helpers.table_grantees('role_permissions'),
+  ARRAY['authenticated'],
+  'authenticated is the only role with table-level privileges'
+);
+SELECT is(
+  test_helpers.all_privs('role_permissions', 'authenticated'),
+  ARRAY['SELECT'],
+  'authenticated has exactly SELECT privileges'
+);
+
+-- RLS: SELECT ------------------------------------------------------------------
+-- The policy is `using (true)` for authenticated, so every authenticated user
+-- can read every row. Catalog rows are seeded by the migration; verify them.
+SELECT test_helpers.create_user('11111111-1111-1111-1111-111111111111');
+
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT bag_eq(
+  $$SELECT role::text, permission::text FROM public.role_permissions$$,
+  $$VALUES ('admin', 'read.users'), ('admin', 'write.users')$$,
+  'allowed: authenticated sees the full role_permissions catalog'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- denied: anon has no grant, SELECT raises insufficient_privilege
+SET LOCAL ROLE anon;
+SELECT throws_ok(
+  $$SELECT id FROM public.role_permissions$$,
+  '42501',
+  NULL,
+  'denied: anon cannot SELECT from role_permissions (no grant)'
+);
+RESET ROLE;
+
+-- ------------------------------------------------------------------------------
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/user_roles_test.sql
+++ b/supabase/tests/database/user_roles_test.sql
@@ -1,0 +1,56 @@
+BEGIN;
+SELECT no_plan();
+
+-- Grants -----------------------------------------------------------------------
+
+SELECT is(
+  test_helpers.col_privs('user_roles', 'authenticated', 'SELECT'),
+  ARRAY['accepted_at', 'created_at', 'deleted_at', 'id', 'invited_at',
+        'role', 'updated_at', 'user_id'],
+  'authenticated can SELECT only the granted columns on user_roles'
+);
+SELECT is(
+  test_helpers.table_grantees('user_roles'),
+  ARRAY['authenticated'],
+  'authenticated is the only role with table-level privileges'
+);
+SELECT is(
+  test_helpers.all_privs('user_roles', 'authenticated'),
+  ARRAY['SELECT'],
+  'authenticated has exactly SELECT privileges'
+);
+
+-- RLS: SELECT ------------------------------------------------------------------
+-- seed two users; give each a member role
+SELECT test_helpers.create_user('11111111-1111-1111-1111-111111111111');
+SELECT test_helpers.create_user('22222222-2222-2222-2222-222222222222');
+
+INSERT INTO public.user_roles (id, user_id, role, accepted_at) VALUES
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+   '11111111-1111-1111-1111-111111111111', 'member', now()),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+   '22222222-2222-2222-2222-222222222222', 'admin', now());
+
+-- allowed: user reads only their own role
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT results_eq(
+  $$SELECT id FROM public.user_roles ORDER BY id$$,
+  $$VALUES ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid)$$,
+  'allowed: authenticated user sees only own user_roles row'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- denied: user cannot read another user's role row
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT is_empty(
+  $$SELECT id FROM public.user_roles
+    WHERE id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'$$,
+  'denied: authenticated user cannot SELECT another user''s role'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- ------------------------------------------------------------------------------
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/users_test.sql
+++ b/supabase/tests/database/users_test.sql
@@ -1,0 +1,46 @@
+BEGIN;
+SELECT no_plan();
+
+-- Grants -----------------------------------------------------------------------
+-- All client-role privileges on public.users are revoked. Application code reads
+-- the user's own row via auth.users / Edge Functions, never through this table.
+
+SELECT is(
+  test_helpers.table_grantees('users'),
+  ARRAY[]::text[],
+  'no client role has table-level privileges on users'
+);
+SELECT is(
+  test_helpers.all_privs('users', 'authenticated'),
+  ARRAY[]::text[],
+  'authenticated has no privileges on users'
+);
+
+-- RLS: SELECT ------------------------------------------------------------------
+-- The table has RLS enabled but defines no policies, so the API surface is fully
+-- locked. The grant revoke trips first; this asserts the lockdown holds regardless.
+
+SELECT test_helpers.create_user('11111111-1111-1111-1111-111111111111');
+
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT throws_ok(
+  $$SELECT id FROM public.users$$,
+  '42501',
+  NULL,
+  'denied: authenticated cannot SELECT from users (no grant)'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+SET LOCAL ROLE anon;
+SELECT throws_ok(
+  $$SELECT id FROM public.users$$,
+  '42501',
+  NULL,
+  'denied: anon cannot SELECT from users (no grant)'
+);
+RESET ROLE;
+
+-- ------------------------------------------------------------------------------
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/visits_test.sql
+++ b/supabase/tests/database/visits_test.sql
@@ -1,0 +1,90 @@
+BEGIN;
+SELECT no_plan();
+
+-- Grants -----------------------------------------------------------------------
+
+SELECT is(
+  test_helpers.col_privs('visits', 'authenticated', 'INSERT'),
+  ARRAY['arrival_location_id', 'departure_location_id', 'id', 'name', 'user_id'],
+  'authenticated can INSERT every column on visits'
+);
+SELECT is(
+  test_helpers.table_grantees('visits'),
+  ARRAY['authenticated'],
+  'authenticated is the only role with table-level privileges'
+);
+SELECT is(
+  test_helpers.all_privs('visits', 'authenticated'),
+  ARRAY['INSERT', 'SELECT', 'UPDATE'],
+  'authenticated has exactly INSERT, SELECT, UPDATE privileges'
+);
+
+-- RLS: SELECT ------------------------------------------------------------------
+SELECT test_helpers.create_user('11111111-1111-1111-1111-111111111111');
+SELECT test_helpers.create_user('22222222-2222-2222-2222-222222222222');
+
+INSERT INTO public.visits (id, user_id, name) VALUES
+  ('visit-owner', '11111111-1111-1111-1111-111111111111', 'Home'),
+  ('visit-other', '22222222-2222-2222-2222-222222222222', 'Office');
+
+-- allowed: owner sees only their own visits
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT results_eq(
+  $$SELECT id FROM public.visits ORDER BY id$$,
+  $$VALUES ('visit-owner'::text)$$,
+  'allowed: authenticated owner sees only own visits'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- denied: non-owner cannot read another user's visit
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('22222222-2222-2222-2222-222222222222');
+SELECT is_empty(
+  $$SELECT id FROM public.visits WHERE id = 'visit-owner'$$,
+  'denied: non-owner cannot SELECT another user''s visit'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- RLS: INSERT ------------------------------------------------------------------
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT throws_ok(
+  $$INSERT INTO public.visits (id, user_id, name)
+    VALUES ('visit-spoof', '22222222-2222-2222-2222-222222222222', 'Spoof')$$,
+  '42501',
+  NULL,
+  'denied: authenticated cannot INSERT a visit for a different user_id'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- RLS: UPDATE ------------------------------------------------------------------
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT is_empty(
+  $$WITH updated AS (
+      UPDATE public.visits SET name = 'hijacked'
+      WHERE id = 'visit-other'
+      RETURNING id
+    )
+    SELECT id FROM updated$$,
+  'denied: non-owner UPDATE returns no rows'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- denied: owner cannot reassign their own row to another user_id (WITH CHECK)
+SET LOCAL ROLE authenticated;
+SELECT test_helpers.set_actor('11111111-1111-1111-1111-111111111111');
+SELECT throws_ok(
+  $$UPDATE public.visits
+    SET user_id = '22222222-2222-2222-2222-222222222222'
+    WHERE id = 'visit-owner'$$,
+  '42501',
+  NULL,
+  'denied: owner cannot UPDATE user_id to another user (WITH CHECK)'
+);
+RESET ROLE; SELECT test_helpers.reset_actor();
+
+-- ------------------------------------------------------------------------------
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

Adds a pgTAP database test suite for every public table, plus a small `devices` hardening fix the tests surfaced.

### Database tests (`supabase/tests/database/`)
- `test_helpers` schema: grant-introspection helpers (`col_privs`, `table_grantees`, `all_privs`), JWT actor simulation, and a user fixture helper.
- One test file per table covering grants and RLS: `users`, `user_roles`, `role_permissions`, `devices`, `raw_location_data`, `visits`, `activity_segments`, `public_info`.
- RLS coverage includes SELECT allow/deny, INSERT spoofing, non-owner UPDATE, and `WITH CHECK` ownership reassignment on user-owned tables.
- `has_permission()` coverage across accepted / pending / deleted / missing role states.

Run with `supabase test db`.

### Other
- `devices.created_at` / `updated_at` are now server-managed (`now()` defaults + `moddatetime` trigger) and excluded from client grants/sync/Drift model. Base migration regenerated from the declarative schema.
- Removed the `custom_access_token` auth hook config pointing at the non-existent `public.user_roles_hook` function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)